### PR TITLE
docs job now runs sequentially but ignores previous jobs skipped. #116

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,8 +80,11 @@ jobs:
     runs-on: self-ubuntu-22.04
     name: Build Antora Site
     needs: generate_reports
-    if: "!contains(github.event.head_commit.message, 'docs skip')"
+    if: always()
     steps:
+    - name: Check if skip
+      if: contains(github.event.head_commit.message, 'docs skip')
+      run: exit 1
     - uses: actions/checkout@v4
     - name: Install credentials
       run: echo https://$GITHUB_OAUTH:@github.com > $HOME/.git-credentials


### PR DESCRIPTION
- Closes #116 

- Added workaround to conditional `need`.  
The `docs` job runs sequentially after `generate_reports`, but it will always run even if previous jobs fail. This ensures that docs are always compiled, but will wait until new .adoc files (if there are new) are built before doing so.
