### PR TITLE
125 automatically extract environment

### DIFF
--- a/config/kub/poznan.json
+++ b/config/kub/poznan.json
@@ -61,10 +61,6 @@
                 {"tasks" : 128, "nodes":1, "exclusive_access":true},
                 {"tasks" : 256, "nodes":2, "exclusive_access":true}
             ]
-        },
-        {
-            "name":"environment",
-            "sequence":["{{machine.prog_environment}}"]
         }
     ]
 }

--- a/config/toolbox_heat/thermal_bridges_case_3.json
+++ b/config/toolbox_heat/thermal_bridges_case_3.json
@@ -77,10 +77,6 @@
         {
             "name": "discretization",
             "sequence": ["P1"]
-        },
-        {
-            "name": "environment",
-            "sequence":["{{machine.prog_environment}}"]
         }
     ]
 }

--- a/config/toolbox_heatfluid/eye.json
+++ b/config/toolbox_heatfluid/eye.json
@@ -87,10 +87,6 @@
         {
             "name": "solver",
             "sequence": ["simple"]
-        },
-        {
-            "name": "environment",
-            "sequence":["{{machine.prog_environment}}"]
         }
     ]
 }

--- a/config/toolbox_thermoelectric/thermoelectric_hl31.json
+++ b/config/toolbox_thermoelectric/thermoelectric_hl31.json
@@ -76,10 +76,6 @@
         {
             "name": "discretization",
             "sequence": ["P1","P2"]
-        },
-        {
-            "name": "environment",
-            "sequence":["{{machine.prog_environment}}"]
         }
     ]
 }

--- a/src/feelpp/benchmarking/report/atomicReports/model.py
+++ b/src/feelpp/benchmarking/report/atomicReports/model.py
@@ -29,6 +29,7 @@ class AtomicReportModel(Model):
                     "status": None,
                     "absolute_error": None,
                     "testcase_time_run": testcase["time_run"],
+                    "environment":testcase["environment"]
                 }
                 for dim, v in testcase["check_params"].items():
                     tmp_dct[dim] = v


### PR DESCRIPTION
- Closes #125 

- Removed `environment` as configuration parameter.
- The reframe report parser now detects the environment from elsewhere. 