### PR TITLE
resolves: 144 add container options field to machine config

### DIFF
--- a/config/kub/poznan.json
+++ b/config/kub/poznan.json
@@ -1,5 +1,5 @@
 {
-    "executable": "/data/home/cladellash/ktirio-urban-building/build/src/cpp/feelpp_kub_cem",
+    "executable": "feelpp_kub_cem",
     "output_directory": "{{machine.output_app_dir}}/kub",
     "use_case_name": "poznan",
     "timeout":"0-0:15:0",

--- a/config/machines/gaya.json
+++ b/config/machines/gaya.json
@@ -2,7 +2,7 @@
     "machine": "gaya",
     "execution_policy": "async",
     "partitions":["production"],
-    "prog_environment":"builtin",
+    "prog_environment":"apptainer",
     "launch_options":["-bind-to core"],
     "reframe_base_dir":"$PWD/build/reframe",
     "reports_base_dir":"$PWD/reports/",

--- a/config/machines/gaya.json
+++ b/config/machines/gaya.json
@@ -12,7 +12,11 @@
         "apptainer":{
             "cachedir": "/home/u2/cladellash/.apptainer/cache",
             "tmpdir": "/data/scratch/cladellash/images/tmp",
-            "image_base_dir":"/data/scratch/cladellash/images"
+            "image_base_dir":"/data/scratch/cladellash/images",
+            "options":[
+                "--sharens",
+                "--bind /opt/:/opt/"
+            ]
         }
     }
 }

--- a/src/feelpp/benchmarking/reframe/config/configMachines.py
+++ b/src/feelpp/benchmarking/reframe/config/configMachines.py
@@ -6,6 +6,7 @@ class Container(BaseModel):
     cachedir:Optional[str] = None
     tmpdir:Optional[str] = None
     image_base_dir:str
+    options:Optional[list[str]] = []
 
     @field_validator("cachedir","tmpdir","image_base_dir",mode="before")
     @classmethod

--- a/src/feelpp/benchmarking/reframe/setup.py
+++ b/src/feelpp/benchmarking/reframe/setup.py
@@ -84,7 +84,7 @@ class MachineSetup(Setup):
             if not os.path.exists(platform.image.name):
                 raise FileExistsError(f"Cannot find image {platform.image.name}")
             rfm_test.container_platform.image = platform.image.name
-            rfm_test.container_platform.options = platform.options
+            rfm_test.container_platform.options = platform.options + self.reader.config.containers[self.reader.config.prog_environment].options
             rfm_test.container_platform.workdir = None
 
     def setTags(self,rfm_test):


### PR DESCRIPTION
- Closes #144 

The machine specific options field has been added to containers on machine configuration: 
```json
"containers":{
        "apptainer":{
            ...
            "options":[
                "--sharens",
                "--bind /opt/:/opt/"
            ]
        }
    }
```

Changes to code: 
- Added `options` to machine schemas
- Append machine specific options on `rfm_test.container_platform.options` during test setup
- Updated gaya and kub configs