### PR TITLE
resolves: 176 specify memory

### DIFF
--- a/config/toolbox_heat/thermal_bridges_case_3.json
+++ b/config/toolbox_heat/thermal_bridges_case_3.json
@@ -3,6 +3,7 @@
     "output_directory": "{{machine.output_app_dir}}/toolboxes/heat/ThermalBridgesENISO10211/Case3",
     "use_case_name": "ThermalBridgesENISO10211",
     "timeout":"0-00:10:00",
+    "memory":"250G",
     "platforms": {
         "apptainer":{
             "image": {
@@ -31,7 +32,7 @@
         "--heat.json.patch='{\"op\": \"replace\",\"path\": \"/Meshes/heat/Import/filename\",\"value\": \"{{platforms.{{machine.platform}}.input_dir}}/partitioning/case3/{{parameters.meshes.value}}/case3_p{{parameters.nb_tasks.tasks.value}}.json\" }'"
     ],
     "env_variables":{
-        "OMP_NUM_THREADS":1
+        "OMP_NUM_THREADS":"1"
     },
     "outputs": [
         {

--- a/src/feelpp/benchmarking/reframe/config/configSchemas.py
+++ b/src/feelpp/benchmarking/reframe/config/configSchemas.py
@@ -82,6 +82,7 @@ class AdditionalFiles(BaseModel):
 class ConfigFile(BaseModel):
     executable: str
     timeout: str
+    memory: Optional[str] = None
     platforms:Optional[Dict[str,Platform]] = {"builtin":Platform()}
     output_directory:Optional[str] = ""
     use_case_name: str


### PR DESCRIPTION
- Closes #176

Added memory to job option. It can now be specified under the `memory` field in the benchmark configuration. 
Functional at the moment, but not optimal nor scalable.
Implementation is not enough general. I'm afraid it won't work for a scheduler other that slurm. 
