### PR TITLE
resolves : 272-support-ctrc-reframe

### DIFF
--- a/src/feelpp/benchmarking/reframe/__main__.py
+++ b/src/feelpp/benchmarking/reframe/__main__.py
@@ -41,8 +41,8 @@ def main_cli():
         executable_name = os.path.basename(app_reader.config.executable).split(".")[0]
         report_folder_path = cmd_builder.createReportFolder(executable_name,app_reader.config.use_case_name)
 
+        #===============PULL IMAGES==================#
         if not parser.args.dry_run:
-            #===============PULL IMAGES==================#
             for platform_name, platform_field in app_reader.config.platforms.items():
                 if not platform_field.image or not platform_field.image.url or not machine_reader.config.containers[platform_name].executable:
                     continue
@@ -51,7 +51,7 @@ def main_cli():
                     completed_pull.check_returncode()
                 else:
                     raise NotImplementedError(f"Image pulling is not yet supported for {platform_name}")
-            #=============================================#
+        #=============================================#
 
         #===== Download remote dependencies ============#
         if not parser.args.dry_run:
@@ -73,28 +73,6 @@ def main_cli():
                     raise NotImplementedError(f"Platform {remote_dependency} is not implemented for {dependency_name}")
         #================================================#
 
-        reframe_cmd = cmd_builder.buildCommand( app_reader.config.timeout)
-
-        exit_code = subprocess.run(reframe_cmd, shell=True)
-
-        #============ CREATING RESULT ITEM ================#
-        with open(os.path.join(report_folder_path,"plots.json"),"w") as f:
-            f.write(json.dumps([p.model_dump() for p in app_reader.config.plots]))
-
-        #Copy use case description if existant
-        FileHandler.copyResource(
-            app_reader.config.additional_files.description_filepath,
-            os.path.join(report_folder_path,"partials"),
-            "description"
-        )
-
-        if parser.args.move_results:
-            if not os.path.exists(parser.args.move_results):
-                os.makedirs(parser.args.move_results)
-            os.rename(os.path.join(report_folder_path,"reframe_report.json"),os.path.join(parser.args.move_results,"reframe_report.json"))
-            os.rename(os.path.join(report_folder_path,"plots.json"),os.path.join(parser.args.move_results,"plots.json"))
-        #======================================================#
-
         #============== UPDATE WEBSITE CONFIG FILE ==============#
         common_itempath = (parser.args.move_results or report_folder_path).split("/")
         common_itempath = "/".join(common_itempath[:-1 - (common_itempath[-1] == "")])
@@ -109,6 +87,37 @@ def main_cli():
         website_config.updateApplication(executable_name)
 
         website_config.save()
+        #======================================================#
+
+
+        # ============== LAUNCH REFRAME =======================#
+        reframe_cmd = cmd_builder.buildCommand( app_reader.config.timeout)
+        exit_code = subprocess.run(reframe_cmd, shell=True)
+        #======================================================#
+
+        #============ CREATING RESULT ITEM ================#
+        with open(os.path.join(report_folder_path,"plots.json"),"w") as f:
+            f.write(json.dumps([p.model_dump() for p in app_reader.config.plots]))
+
+        #Copy use case description if existant
+        FileHandler.copyResource(
+            app_reader.config.additional_files.description_filepath,
+            os.path.join(report_folder_path,"partials"),
+            "description"
+        )
+        #===============================================#
+
+        # ============== LAUNCH REFRAME =======================#
+        reframe_cmd = cmd_builder.buildCommand( app_reader.config.timeout)
+        exit_code = subprocess.run(reframe_cmd, shell=True)
+        #======================================================#
+
+        # ================== MOVE RESULTS (OPTION)============#
+        if parser.args.move_results:
+            if not os.path.exists(parser.args.move_results):
+                os.makedirs(parser.args.move_results)
+            os.rename(os.path.join(report_folder_path,"reframe_report.json"),os.path.join(parser.args.move_results,"reframe_report.json"))
+            os.rename(os.path.join(report_folder_path,"plots.json"),os.path.join(parser.args.move_results,"plots.json"))
         #======================================================#
 
     if parser.args.website:


### PR DESCRIPTION
It is now possible to Ctrl+C while tests are running to stop remaining tests, and update website configuration and export files accordingly. 

- Closes #272 


NOTE: 
It's not trivial to update the report file after each test is done (to render the website on-the-go) , as it's session dependent. It does not seem to be a Reframe built-in functionality for this (YET). 