### PR TITLE
resolves: 276 Memory constraint not correctly taken into account

### DIFF
--- a/src/feelpp/benchmarking/reframe/resources.py
+++ b/src/feelpp/benchmarking/reframe/resources.py
@@ -91,23 +91,16 @@ class MemoryEnforcer:
         assert self.memory > 0, "Memory should be strictly positive"
 
     def enforceMemory(self, rfm_test):
-        min_nodes_required = int(np.ceil(self.memory / rfm_test.current_partition.extras["memory_per_node"])) #ceil( 2500/256 ) = 10
-        memory_per_task = self.memory / rfm_test.num_tasks #2500/1280 ---- 2500/1024 = 1,9531 ---- 2,4414
-        max_tasks_per_node_mem = rfm_test.current_partition.extras["memory_per_node"] // memory_per_task  # 256/1,9531 = 131,0723 ---- 256/2,4414 = 104,8576 --> 131 -- 104
-        max_tasks_per_node = min(max_tasks_per_node_mem, rfm_test.current_partition.processor.num_cpus) # min(131, 128) = 128 --- min(104, 128) = 104
+        min_nodes_required = int(np.ceil(self.memory / rfm_test.current_partition.extras["memory_per_node"]))
+        memory_per_task = self.memory / rfm_test.num_tasks
+        max_tasks_per_node_mem = rfm_test.current_partition.extras["memory_per_node"] // memory_per_task
+        max_tasks_per_node = min(max_tasks_per_node_mem, rfm_test.current_partition.processor.num_cpus)
 
-        rfm_test.num_nodes = max(min_nodes_required, rfm_test.num_nodes)  #max ( 10, ceil(1280/128)) = max(10, 10) = 10 ------ max (10, ceil(1024/128)) = max(10, 8) = 10
-
+        rfm_test.num_nodes = max(min_nodes_required, rfm_test.num_nodes)
 
         if self.memory > rfm_test.current_partition.extras["memory_per_node"]:
-            tpn = rfm_test.num_tasks // rfm_test.num_nodes # floor(1280/10) = 128 ---- floor(1024/10) = 102
-            if rfm_test.num_tasks_per_node is None:
-                rfm_test.num_tasks_per_node = tpn
-            else:
-                rfm_test.num_tasks_per_node = max(min(tpn , rfm_test.num_tasks_per_node), 1) #min(128, 128) = 128 ---- min(102, 128) = 102
-
-            rfm_test.num_nodes = int(np.ceil(rfm_test.num_tasks / rfm_test.num_tasks_per_node)) # ceil(1280/128) = 10 ---- ceil(1024/102) = 11
-            assert rfm_test.num_tasks_per_node <= max_tasks_per_node, f"Number of tasks per node ({rfm_test.num_tasks_per_node}) should be less than {max_tasks_per_node}"
+            rfm_test.job.options += [f"--nodes={rfm_test.num_nodes}"]
+            rfm_test.num_tasks_per_node = None
 
         app_memory_per_node = int(np.ceil(self.memory / rfm_test.num_nodes))
         assert app_memory_per_node <= rfm_test.current_partition.extras["memory_per_node"], f"Memory per node ({app_memory_per_node}) should be less than {rfm_test.current_partition.extras['memory_per_node']}"

--- a/tests/parameters/test_resources.py
+++ b/tests/parameters/test_resources.py
@@ -147,10 +147,10 @@ class TestResourcesStrategies:
             assert rfm_test.num_gpus_per_node == gpus_per_node
 
     @pytest.mark.parametrize(("tasks","memory","expected_nodes","expected_tasks_per_node"), [
-        (128, 900, 1, 128), (128, 1000, 1, 128), (128, 1100, 2, 64), (128, 2100, 4, 42),
-        (64, 500, 1, 64), (64, 1000, 1, 64), (64, 1100, 2, 32),
-        (256, 900, 2, 128), (256, 1100, 2, 128), (256, 2500, 4, 85), (256, 3500, 4, 64),
-        (301, 900, 3, 128), (301, 1100, 4, 100), (301, 4100, 6, 60)
+        (128, 900, 1, 128), (128, 1000, 1, 128), (128, 1100, 2, None), (128, 2100, 3, None),
+        (64, 500, 1, 64), (64, 1000, 1, 64), (64, 1100, 2, None),
+        (256, 900, 2, 128), (256, 1100, 2, None), (256, 2500, 3, None), (256, 3500, 4, None),
+        (301, 900, 3, 128), (301, 1100, 3, None), (301, 4100, 5, None)
     ])
     def test_memoryEnforcer(self, tasks, memory, expected_nodes, expected_tasks_per_node):
         """ Tests the MemoryEnforcer


### PR DESCRIPTION
Problem was that, if memory provided, the number of nodes was determined from the number of tasks per node.

The proposed solution hard sets `--nodes` on the slurm script, and forces num_tasks_per_node to None on ReFrame. 
This way, SLURM is responsible of distributing tasks across nodes.

❗ WARNING ❗ 
Possible issue: this does not ensure that it will work for scheduler other than SLURM.

- Closes #276 