### PR TITLE
resolves : Bug on renaming variables when on axis

### DIFF
--- a/src/feelpp/benchmarking/report/figures/base.py
+++ b/src/feelpp/benchmarking/report/figures/base.py
@@ -28,8 +28,8 @@ class Figure:
             list[dict[str,str]]: A list of dictionaries containing the csv strings and their corresponding titles.
             Schema: [{"title":str, "data":str}]
         """
-        df = self.transformation_strategy.calculate(df)
         df = self.renameColumns(df)
+        df = self.transformation_strategy.calculate(df)
         if isinstance(df.index,MultiIndex):
             return [{"title":key, "data":df.xs(key, level=0).to_csv()} for key in df.index.levels[0]]
         else:
@@ -42,8 +42,8 @@ class Figure:
         Returns:
             go.Figure: Plotly figure corresponding to the grouped Bar type
         """
-        df = self.transformation_strategy.calculate(df)
         df = self.renameColumns(df)
+        df = self.transformation_strategy.calculate(df)
         if isinstance(df.index,MultiIndex):
             figure = self.createMultiindexFigure(df, **args)
         else:
@@ -54,7 +54,9 @@ class Figure:
     def renameColumns(self,df):
         if self.config.variables and self.config.names:
             assert len(self.config.variables) == len(self.config.names)
-            df = df.rename(columns = {var:name for var,name in zip(self.config.variables,self.config.names)})
+
+            df["performance_variable"] = df["performance_variable"].replace(self.config.variables, self.config.names)
+
 
         return df
 

--- a/src/feelpp/benchmarking/report/transformationFactory.py
+++ b/src/feelpp/benchmarking/report/transformationFactory.py
@@ -158,12 +158,14 @@ class TransformationStrategyFactory:
         }
         aggregations = plot_config.aggregations
 
+        variables = plot_config.names or plot_config.variables
+
         if plot_config.transformation == "performance":
-            return PerformanceStrategy(dimensions,aggregations,plot_config.variables)
+            return PerformanceStrategy(dimensions,aggregations,variables)
         elif plot_config.transformation == "speedup":
-            return SpeedupStrategy(dimensions,aggregations,plot_config.variables)
+            return SpeedupStrategy(dimensions,aggregations,variables)
         elif plot_config.transformation == "relative_performance":
-            return RelativePerformanceStrategy(dimensions,aggregations,plot_config.variables)
+            return RelativePerformanceStrategy(dimensions,aggregations,variables)
         else:
             raise NotImplementedError
 

--- a/tests/report/test_transformationFactory.py
+++ b/tests/report/test_transformationFactory.py
@@ -13,7 +13,7 @@ class PlotConfigMocker:
     def __init__(
         self, transformation="",aggregations = [],
         xaxis = AxisMocker(), secondary_axis= AxisMocker(), color_axis=AxisMocker(),
-        variables = [], plot_types = [], layout_modifiers = None, title = "", yaxis = AxisMocker(), extra_axes = []
+        variables = [], names=[], plot_types = [], layout_modifiers = None, title = "", yaxis = AxisMocker(), extra_axes = []
     ):
         self.transformation = transformation
         self.xaxis = xaxis
@@ -25,6 +25,7 @@ class PlotConfigMocker:
         self.plot_types = plot_types
         self.layout_modifiers = layout_modifiers
         self.title = title
+        self.names = names
         self.extra_axes = extra_axes
 
 @pytest.mark.parametrize(("transformation","strategy"),[


### PR DESCRIPTION
Column renaming is now done before transformations 
It allows renaming variables when performance_variable is on an axis other than color_axis.

 